### PR TITLE
contrib: add check for wget command in install_db4.sh

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -55,8 +55,11 @@ http_get() {
     echo "File ${2} already exists; not downloading again"
   elif check_exists curl; then
     curl --insecure --retry 5 "${1}" -o "${2}"
-  else
+  elif check_exists wget; then
     wget --no-check-certificate "${1}" -O "${2}"
+  else
+    echo "Simple transfer utilities 'curl' and 'wget' not found. Please install one of them and try again."
+    exit 1
   fi
 
   sha256_check "${3}" "${2}"
@@ -64,7 +67,7 @@ http_get() {
 
 # Ensure the commands we use exist on the system
 if ! check_exists patch; then
-    echo "Command-line tool 'patch' not found.  Install patch and try again."
+    echo "Command-line tool 'patch' not found. Install patch and try again."
     exit 1
 fi
 


### PR DESCRIPTION
This PR is motivated by https://github.com/bitcoin/bitcoin/commit/7bb8eb0bc352b47ee962283898f9becbb4f36c62 (see also https://github.com/bitcoin/bitcoin/pull/23579) and ensures that `install_db4.sh` will check for `curl` and `wget` utilities. Currently, the conditional statement in the `http_get()` function assumes that `wget` is always available but we actually do not know it since there is no check or validation for the `wget` command. So let's make sure that we check for both commands and print an error message if they are missing.